### PR TITLE
Add placeholder to differentiate the commands

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ export default class CssEditorPlugin extends Plugin {
 			callback: async () => {
 				new CssSnippetFuzzySuggestModal(
 					this.app,
+					"EDIT the chosen CSS file (or press ESC to abort)",
 					this.openCssEditorView
 				).open();
 			},
@@ -42,14 +43,17 @@ export default class CssEditorPlugin extends Plugin {
 			id: "delete-css-snippet",
 			name: "Delete CSS Snippet",
 			callback: async () => {
-				new CssSnippetFuzzySuggestModal(this.app, (item) => {
-					deleteSnippetFile(this.app, item);
-					detachLeavesOfTypeAndDisplay(
-						this.app.workspace,
-						VIEW_TYPE_CSS,
-						item
-					);
-					new InfoNotice(`${item} was deleted.`);
+				new CssSnippetFuzzySuggestModal(
+					this.app,
+					"DELETE the chosen CSS file (or press ESC to abort)", 
+					(item) => {
+						deleteSnippetFile(this.app, item);
+						detachLeavesOfTypeAndDisplay(
+							this.app.workspace,
+							VIEW_TYPE_CSS,
+							item
+						);
+						new InfoNotice(`${item} was deleted.`);
 				}).open();
 			},
 		});

--- a/src/modals/CssSnippetFuzzySuggestModal.ts
+++ b/src/modals/CssSnippetFuzzySuggestModal.ts
@@ -1,13 +1,15 @@
-import { App, FuzzyMatch, FuzzySuggestModal } from "obsidian";
+import { App, FuzzyMatch, FuzzySuggestModal, Platform, Notice } from "obsidian";
 import { getSnippetDirectory } from "../obsidian/file-system-helpers";
 
 export class CssSnippetFuzzySuggestModal extends FuzzySuggestModal<string> {
 	constructor(
 		app: App,
+		placeHolder: string, 
 		onChooseItem: (item: string, evt: MouseEvent | KeyboardEvent) => void
 	) {
 		super(app);
 		this.onChooseItem = onChooseItem;
+		this.setPlaceholder(placeHolder);
 		this.scope.register(["Meta"], "Enter", (evt: KeyboardEvent) => {
 			if (!evt.isComposing && this.chooser?.useSelectedItem?.(evt)) {
 				return false;


### PR DESCRIPTION
Currently you don't really now if you've started the delete or the edit command, and I on one occasions deleted one of my snippets as triggered the wrong variant. 

This PR simply adds a placeholder text so that it's clear whichever command variant one have initiated. 

For edit:
![image](https://github.com/Zachatoo/obsidian-css-editor/assets/11348165/f8c9e172-f03a-4008-af57-83791d319dec)

For delete:
![image](https://github.com/Zachatoo/obsidian-css-editor/assets/11348165/2f3ffac8-71ec-4a1f-ad32-f212383e052f)
