### PR TITLE
Feature: Enable/disable snippets from switcher

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { Plugin } from "obsidian";
 import { CssEditorView, VIEW_TYPE_CSS } from "src/views/CssEditorView";
 import { CssSnippetFuzzySuggestModal } from "src/modals/CssSnippetFuzzySuggestModal";
 import { ignoreObsidianHotkey } from "src/obsidian/ignore-obsidian-hotkey";
-import { deleteSnippetFile } from "./obsidian/file-system-helpers";
+import { deleteSnippetFile, toggleSnippetFileState } from "./obsidian/file-system-helpers";
 import { detachLeavesOfTypeAndDisplay } from "./obsidian/workspace-helpers";
 import { InfoNotice } from "./obsidian/Notice";
 
@@ -39,8 +39,22 @@ export default class CssEditorPlugin extends Plugin {
 						VIEW_TYPE_CSS,
 						filename
 					);
-					new InfoNotice(`${filename} was deleted.`);
+					new InfoNotice(`"${filename}" was deleted.`);
 				});
+			},
+		});
+
+		this.addCommand({
+			id: "toggle-css-snippet",
+			name: "Toggle state of current CSS snippet",
+			checkCallback: (checking) => {
+				const activeCssEditorView =
+					this.app.workspace.getActiveViewOfType(CssEditorView);
+				if (!activeCssEditorView) return false;
+				if (checking) return true;
+				const { filename } = activeCssEditorView.getState();
+				const newState = toggleSnippetFileState(this.app, filename);
+				new InfoNotice(`State of "${filename}" is ${ newState }.`);
 			},
 		});
 

--- a/src/obsidian/file-system-helpers.ts
+++ b/src/obsidian/file-system-helpers.ts
@@ -49,6 +49,17 @@ export async function deleteSnippetFile(app: App, fileName: string) {
 	await app.vault.adapter.remove(`${getSnippetDirectory(app)}${fileName}`);
 }
 
+export function toggleSnippetFileState(app: App, fileName: string) {
+	const snippetName = fileName.replace(".css", "");
+    const isEnabled = app.customCss?.enabledSnippets?.has(snippetName);
+	if (isEnabled !== undefined) {
+		app.customCss?.setCssEnabledStatus?.(snippetName, !isEnabled);
+		return !isEnabled ? "now enabled" : "now disabled"
+	} else {
+		return "not known"
+	}
+}
+
 async function _createSnippetDirectoryIfNotExists(app: App) {
 	if (!(await app.vault.adapter.exists(getSnippetDirectory(app)))) {
 		await app.vault.adapter.mkdir(getSnippetDirectory(app));

--- a/src/obsidian/obsidian.d.ts
+++ b/src/obsidian/obsidian.d.ts
@@ -9,6 +9,7 @@ declare module "obsidian" {
 					setCssEnabledStatus:
 						| ((name: string, value: boolean) => void)
 						| undefined;
+					enabledSnippets: Set<String> | undefined;
 			  }
 			| undefined;
 		plugins: {
@@ -22,7 +23,16 @@ declare module "obsidian" {
 	interface FuzzySuggestModal<T> {
 		chooser?: {
 			useSelectedItem?: (evt: KeyboardEvent) => boolean;
+			selectedItem: number;
+			values: {
+				item: String,
+				match: {
+					score: number,
+					matches: string[]
+				}
+			}[];
 			setSuggestions?: (suggestions: FuzzyMatch<T>[]) => void;
+			suggestions: HTMLElement[];
 			addMessage?: (text: string) => HTMLDivElement;
 		};
 	}

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,17 @@
 .suggestion-item .css-editor-suggestion-description {
 	color: var(--text-muted);
 }
+
+.css-editor-status {
+	border-radius: 5px;
+	border: 1px solid var(--color-base-50);
+	padding: 2px 6px;
+  
+	&.enabled {
+	  background-color: var(--color-accent);
+	}
+  
+	&.disabled {
+	  background-color: var(--background-secondary-alt);
+	}
+  }


### PR DESCRIPTION
Implementing #21 enabling enabling/disabling snippets from the switcher.

With these changes enabled now the switcher looks like:

![image](https://github.com/Zachatoo/obsidian-css-editor/assets/11348165/5a3f45e1-31f0-422b-842d-103482e9c76f)

I've chosen <code>Tab</code> as the character to toggle enabled/disabled, and the color for enabled is the accented color. 