### PR TITLE
Made some improvements to the editor

### DIFF
--- a/src/codemirror-extensions/basic-extensions.ts
+++ b/src/codemirror-extensions/basic-extensions.ts
@@ -3,8 +3,7 @@ import {
 	history,
 	historyKeymap,
 	indentWithTab,
-} from "@codemirror/commands";
-import { css } from "@codemirror/lang-css";
+} from "@codemirror/commands";;
 import {
 	bracketMatching,
 	foldGutter,
@@ -22,6 +21,7 @@ import {
 import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
 import { lintKeymap } from "@codemirror/lint";
 import { obsidian } from "./obsidian-theme";
+import { css } from "./reconfigured-css";
 
 export const basicExtensions: Extension[] = [
 	keymap.of([

--- a/src/codemirror-extensions/basic-extensions.ts
+++ b/src/codemirror-extensions/basic-extensions.ts
@@ -28,6 +28,7 @@ import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
 import { lintKeymap } from "@codemirror/lint";
 import { obsidian } from "./obsidian-theme";
 import { css } from "./reconfigured-css";
+import { highlightActiveLine } from "./highlight-active-line";
 
 export const basicExtensions: Extension[] = [
 	keymap.of([
@@ -48,6 +49,7 @@ export const basicExtensions: Extension[] = [
 	dropCursor(),
 	drawSelection({ drawRangeCursor: true }),
 	EditorState.allowMultipleSelections.of(true),
+	highlightActiveLine(),
 	indentOnInput(),
 	bracketMatching(),
 	autocompletion(),

--- a/src/codemirror-extensions/basic-extensions.ts
+++ b/src/codemirror-extensions/basic-extensions.ts
@@ -40,7 +40,6 @@ export const basicExtensions: Extension[] = [
 	dropCursor(),
 	EditorState.allowMultipleSelections.of(true),
 	indentOnInput(),
-	EditorView.lineWrapping,
 	bracketMatching(),
 	autocompletion(),
 	closeBrackets(),

--- a/src/codemirror-extensions/basic-extensions.ts
+++ b/src/codemirror-extensions/basic-extensions.ts
@@ -11,7 +11,8 @@ import {
 	indentOnInput,
 } from "@codemirror/language";
 import { EditorState, Extension } from "@codemirror/state";
-import { dropCursor, EditorView, keymap } from "@codemirror/view";
+	lineNumbers,
+	highlightActiveLineGutter,
 import {
 	autocompletion,
 	closeBrackets,
@@ -36,7 +37,9 @@ export const basicExtensions: Extension[] = [
 	]),
 	history(),
 	css(),
+	lineNumbers(),
 	foldGutter(),
+	highlightActiveLineGutter(),
 	dropCursor(),
 	EditorState.allowMultipleSelections.of(true),
 	indentOnInput(),

--- a/src/codemirror-extensions/basic-extensions.ts
+++ b/src/codemirror-extensions/basic-extensions.ts
@@ -3,7 +3,7 @@ import {
 	history,
 	historyKeymap,
 	indentWithTab,
-} from "@codemirror/commands";;
+} from "@codemirror/commands";
 import {
 	bracketMatching,
 	foldGutter,

--- a/src/codemirror-extensions/basic-extensions.ts
+++ b/src/codemirror-extensions/basic-extensions.ts
@@ -11,8 +11,13 @@ import {
 	indentOnInput,
 } from "@codemirror/language";
 import { EditorState, Extension } from "@codemirror/state";
+import {
+	dropCursor,
+	keymap,
 	lineNumbers,
 	highlightActiveLineGutter,
+	drawSelection,
+} from "@codemirror/view";
 import {
 	autocompletion,
 	closeBrackets,
@@ -41,6 +46,7 @@ export const basicExtensions: Extension[] = [
 	foldGutter(),
 	highlightActiveLineGutter(),
 	dropCursor(),
+	drawSelection({ drawRangeCursor: true }),
 	EditorState.allowMultipleSelections.of(true),
 	indentOnInput(),
 	bracketMatching(),

--- a/src/codemirror-extensions/compartments.ts
+++ b/src/codemirror-extensions/compartments.ts
@@ -1,0 +1,4 @@
+import { Compartment } from "@codemirror/state";
+
+export const lineWrap = new Compartment();
+export const indentSize = new Compartment();

--- a/src/codemirror-extensions/highlight-active-line.ts
+++ b/src/codemirror-extensions/highlight-active-line.ts
@@ -3,7 +3,7 @@ import { layer, LayerMarker, RectangleMarker } from "@codemirror/view";
 // We don't use builtin active line highlighter from CodeMirror,
 // because it sets the background of active line DOM, which can cause
 // blocking appearance of selection that's drawn via DOM (not native selection),
-// e.g. the second selection (or all of them when builtin "highlightActiveLine()"
+// e.g. the second selection (or all of selections when "drawSelection()"
 // is registered).
 export function highlightActiveLine() {
     return activeLineLayer;

--- a/src/codemirror-extensions/highlight-active-line.ts
+++ b/src/codemirror-extensions/highlight-active-line.ts
@@ -23,7 +23,6 @@ const activeLineLayer = layer({
             let { top, height } = view.lineBlockAt(r.head),
                 layer = new RectangleMarker("cm-activeLine", contentLeft - scrollerLeft, top + paddingTop, width, height);
             markers.push(layer);
-            layer.draw();
         }
         return markers;
     },

--- a/src/codemirror-extensions/highlight-active-line.ts
+++ b/src/codemirror-extensions/highlight-active-line.ts
@@ -14,13 +14,14 @@ const activeLineLayer = layer({
     above: false,
     class: "cm-activeLineLayer",
     markers(view) {
-        let selection = view.state.selection,
+        const selection = view.state.selection,
             markers: LayerMarker[] = [],
             paddingTop = view.documentPadding.top,
             { width, left: contentLeft } = view.contentDOM.getBoundingClientRect(),
             { left: scrollerLeft } = view.scrollDOM.getBoundingClientRect();
-        for (let r of selection.ranges) {
-            let { top, height } = view.lineBlockAt(r.head),
+
+        for (const range of selection.ranges) {
+            const { top, height } = view.lineBlockAt(range.head),
                 layer = new RectangleMarker("cm-activeLine", contentLeft - scrollerLeft, top + paddingTop, width, height);
             markers.push(layer);
         }

--- a/src/codemirror-extensions/highlight-active-line.ts
+++ b/src/codemirror-extensions/highlight-active-line.ts
@@ -1,0 +1,33 @@
+import { layer, LayerMarker, RectangleMarker } from "@codemirror/view";
+
+// We don't use builtin active line highlighter from CodeMirror,
+// because it sets the background of active line DOM, which can cause
+// blocking appearance of selection that's drawn via DOM (not native selection),
+// e.g. the second selection (or all of them when builtin "highlightActiveLine()"
+// is registered).
+export function highlightActiveLine() {
+    return activeLineLayer;
+}
+
+// Use layer instead decoration
+const activeLineLayer = layer({
+    above: false,
+    class: "cm-activeLineLayer",
+    markers(view) {
+        let selection = view.state.selection,
+            markers: LayerMarker[] = [],
+            paddingTop = view.documentPadding.top,
+            { width, left: contentLeft } = view.contentDOM.getBoundingClientRect(),
+            { left: scrollerLeft } = view.scrollDOM.getBoundingClientRect();
+        for (let r of selection.ranges) {
+            let { top, height } = view.lineBlockAt(r.head),
+                layer = new RectangleMarker("cm-activeLine", contentLeft - scrollerLeft, top + paddingTop, width, height);
+            markers.push(layer);
+            layer.draw();
+        }
+        return markers;
+    },
+    update(update) {
+        return update.docChanged || update.selectionSet || update.viewportChanged || update.geometryChanged;
+    }
+});

--- a/src/codemirror-extensions/obsidian-theme.ts
+++ b/src/codemirror-extensions/obsidian-theme.ts
@@ -12,7 +12,7 @@ export const config = {
 	cursor: "var(--text-normal)",
 	dropdownBackground: "var(--background-primary)",
 	dropdownBorder: "var(--background-modifier-border)",
-	activeLine: "var(--background-primary)",
+	activeLineNumber: "var(--text-normal)",
 	matchingBracket: "var(--background-modifier-accent)",
 	keyword: "#d73a49",
 	storage: "#d73a49",
@@ -58,7 +58,12 @@ export const obsidianTheme = EditorView.theme(
 		},
 
 		".cm-activeLine": { backgroundColor: config.activeLine },
-		".cm-activeLineGutter": { backgroundColor: config.background },
+		".cm-activeLineGutter": {
+			backgroundColor: config.activeLine,
+			".cm-lineNumbers &": {
+				color: config.activeLineNumber,
+			},
+		},
 		".cm-selectionMatch": { backgroundColor: config.selection },
 
 		".cm-matchingBracket, .cm-nonmatchingBracket": {

--- a/src/codemirror-extensions/obsidian-theme.ts
+++ b/src/codemirror-extensions/obsidian-theme.ts
@@ -12,6 +12,7 @@ export const config = {
 	cursor: "var(--text-normal)",
 	dropdownBackground: "var(--background-primary)",
 	dropdownBorder: "var(--background-modifier-border)",
+	activeLine: "var(--background-secondary)",
 	activeLineNumber: "var(--text-normal)",
 	matchingBracket: "var(--background-modifier-accent)",
 	keyword: "#d73a49",

--- a/src/codemirror-extensions/obsidian-theme.ts
+++ b/src/codemirror-extensions/obsidian-theme.ts
@@ -27,6 +27,7 @@ export const config = {
 	comment: "var(--text-faint)",
 	invalid: "var(--text-error)",
 	regexp: "#032f62",
+	monospace: "var(--font-monospace)",
 };
 
 export const obsidianTheme = EditorView.theme(
@@ -35,6 +36,8 @@ export const obsidianTheme = EditorView.theme(
 			color: config.foreground,
 			backgroundColor: config.background,
 		},
+
+		".cm-scroller": { fontFamily: config.monospace },
 
 		".cm-content": { caretColor: config.cursor },
 
@@ -89,10 +92,13 @@ export const obsidianTheme = EditorView.theme(
 			color: config.foreground,
 		},
 		".cm-tooltip.cm-tooltip-autocomplete": {
-			"& > ul > li[aria-selected]": {
-				background: config.selection,
-				color: config.foreground,
-			},
+			"& > ul": {
+				fontFamily: config.monospace,
+				"& > li[aria-selected]": {
+					background: config.selection,
+					color: config.foreground
+				}
+			}
 		},
 	},
 	{ dark: config.dark }

--- a/src/codemirror-extensions/obsidian-theme.ts
+++ b/src/codemirror-extensions/obsidian-theme.ts
@@ -42,7 +42,7 @@ export const obsidianTheme = EditorView.theme(
 		".cm-content": { caretColor: config.cursor },
 
 		"&.cm-focused .cm-cursor": { borderLeftColor: config.cursor },
-		"&.cm-focused .cm-selectionBackground, .cm-selectionBackground, & ::selection":
+		".cm-selectionBackground, &.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, & ::selection":
 			{ backgroundColor: config.selection },
 
 		".cm-panels": {

--- a/src/codemirror-extensions/reconfigured-css.ts
+++ b/src/codemirror-extensions/reconfigured-css.ts
@@ -53,16 +53,16 @@ function getSelectorNames(state: EditorState, node: SyntaxNode, type: SelectorTy
     // As a single Tree may consist of several pieces, especially when its length exceeds 4 kB of
     // chars, caching the class/id names and mapping them to the correspond node could be an efficient way
     if (node.to - node.from > 4096) {
-        let known = SelectorsByNode[type].get(node);
+        const known = SelectorsByNode[type].get(node);
         if (known)
             return known;
 
-        let result: Completion[] = [],
+        const result: Completion[] = [],
             seen = new Set<string>(),
             cursor = node.cursor(IterMode.IncludeAnonymous);
         if (cursor.firstChild())
             do {
-                for (let option of getSelectorNames(state, cursor.node, type))
+                for (const option of getSelectorNames(state, cursor.node, type))
                     if (!seen.has(option.label)) {
                         seen.add(option.label);
                         result.push(option);
@@ -73,12 +73,12 @@ function getSelectorNames(state: EditorState, node: SyntaxNode, type: SelectorTy
     }
 
     else {
-        let result: Completion[] = [],
+        const result: Completion[] = [],
             seen = new Set<string>(),
             { doc, selection } = state;
         node.cursor().iterate(node => {
             if (type == isSelectorIdentifier(node) && !touchSelection(selection, node)) {
-                let name = doc.sliceString(node.from, node.to);
+                const name = doc.sliceString(node.from, node.to);
                 if (!seen.has(name)) {
                     seen.add(name);
                     result.push({ label: name, type: "variable" });
@@ -94,12 +94,12 @@ const cssCompletionSource: CompletionSource = context => {
     let result = defineCSSCompletionSource(node => node.name == "VariableName")(context);
 
     if (!result) {
-        let { state, pos } = context,
+        const { state, pos } = context,
             node = syntaxTree(state).resolveInner(pos, -1);
         
         // Class selector
         if (node.matchContext(ClassSelectorCtx)) {
-            let isDot = node.name == ".";
+            const isDot = node.name == ".";
             result = {
                 from: isDot ? node.to : node.from,
                 options: getSelectorNames(state, getASTTop(node), SelectorType.CLASS),
@@ -109,7 +109,7 @@ const cssCompletionSource: CompletionSource = context => {
         
         // Id selector
         else if (node.matchContext(IdSelectorCtx)) {
-            let isHash = node.name == "#";
+            const isHash = node.name == "#";
             result = {
                 from: isHash ? node.to : node.from,
                 options: getSelectorNames(state, getASTTop(node), SelectorType.ID),

--- a/src/codemirror-extensions/reconfigured-css.ts
+++ b/src/codemirror-extensions/reconfigured-css.ts
@@ -1,0 +1,124 @@
+import { Completion, CompletionSource } from "@codemirror/autocomplete";
+import { cssLanguage, defineCSSCompletionSource } from "@codemirror/lang-css";
+import { LanguageSupport, syntaxTree } from "@codemirror/language";
+import { EditorSelection, EditorState } from "@codemirror/state";
+import { IterMode, NodeWeakMap, SyntaxNode, SyntaxNodeRef } from "@lezer/common";
+
+// Most codes were taken/replicated from "@codemirror/lang-css"
+// Add auto-completion logic for class and id selector
+
+const enum SelectorType {
+    CLASS = "class",
+    ID = "id"
+}
+
+const ClassSelectorCtx = ["ClassSelector"];
+const IdSelectorCtx = ["IdSelector"];
+
+// Use weak map, so we don't need to manually clear it each time the Tree updated and won't be reused again
+const SelectorsByNode = {
+    [SelectorType.CLASS]: new NodeWeakMap<Completion[]>(),
+    [SelectorType.ID]: new NodeWeakMap<Completion[]>(),
+};
+
+const Identifier = /^(\w[\w-]*|-\w[\w-]*|)$/;
+
+function getASTTop(node: SyntaxNode) {
+    for (let cur: SyntaxNode | null = node;;) {
+        if (cur.type.isTop)
+            return cur;
+        if (!(cur = cur.parent))
+            return node;
+    }
+}
+
+function isSelectorIdentifier(node: SyntaxNodeRef) {
+    if (node.name == "ClassName")
+        return SelectorType.CLASS;
+    if (node.name == "IdName")
+        return SelectorType.ID;
+    return false;
+}
+
+function touchSelection(selection: EditorSelection, range: { from: number, to: number }) {
+    return selection.ranges.findIndex(selRange =>
+        selRange.from <= range.to &&
+        selRange.to >= range.from
+    ) >= 0;
+}
+
+// Refer to variableNames() at "@codemirror/lang-css/dist/index.cjs"
+// Retrieve list of class/id names to be used in selector auto-completion
+function getSelectorNames(state: EditorState, node: SyntaxNode, type: SelectorType) {
+    // As a single Tree may consist of several pieces, especially when its length exceeds 4 kB of
+    // chars, caching the class/id names and mapping them to the correspond node could be an efficient way
+    if (node.to - node.from > 4096) {
+        let known = SelectorsByNode[type].get(node);
+        if (known)
+            return known;
+
+        let result: Completion[] = [],
+            seen = new Set<string>(),
+            cursor = node.cursor(IterMode.IncludeAnonymous);
+        if (cursor.firstChild())
+            do {
+                for (let option of getSelectorNames(state, cursor.node, type))
+                    if (!seen.has(option.label)) {
+                        seen.add(option.label);
+                        result.push(option);
+                    }
+            } while (cursor.nextSibling());
+        SelectorsByNode[type].set(node, result);
+        return result;
+    }
+
+    else {
+        let result: Completion[] = [],
+            seen = new Set<string>(),
+            { doc, selection } = state;
+        node.cursor().iterate(node => {
+            if (type == isSelectorIdentifier(node) && !touchSelection(selection, node)) {
+                let name = doc.sliceString(node.from, node.to);
+                if (!seen.has(name)) {
+                    seen.add(name);
+                    result.push({ label: name, type: "variable" });
+                }
+            }
+        });
+        return result;
+    }
+}
+
+const cssCompletionSource: CompletionSource = context => {
+    // Original
+    let result = defineCSSCompletionSource(node => node.name == "VariableName")(context);
+
+    if (!result) {
+        let { state, pos } = context,
+            node = syntaxTree(state).resolveInner(pos, -1);
+        
+        // Class selector
+        if (node.matchContext(ClassSelectorCtx)) {
+            let isDot = node.name == ".";
+            result = {
+                from: isDot ? node.to : node.from,
+                options: getSelectorNames(state, getASTTop(node), SelectorType.CLASS),
+                validFor: Identifier
+            };
+        }
+        
+        // Id selector
+        else if (node.matchContext(IdSelectorCtx)) {
+            let isHash = node.name == "#";
+            result = {
+                from: isHash ? node.to : node.from,
+                options: getSelectorNames(state, getASTTop(node), SelectorType.ID),
+                validFor: Identifier
+            };
+        }
+    }
+
+    return result;
+}
+
+export const css = () => new LanguageSupport(cssLanguage, cssLanguage.data.of({ autocomplete: cssCompletionSource }));

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,14 +11,22 @@ import { detachCssFileLeaves, openView } from "./obsidian/workspace-helpers";
 import { InfoNotice } from "./obsidian/Notice";
 import { CssSnippetCreateModal } from "./modals/CssSnippetCreateModal";
 import { CssFile } from "./CssFile";
+import { CSSEditorSettingTab } from "./obsidian/setting-tab";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface CssEditorPluginSettings {}
+export interface CssEditorPluginSettings {
+	lineWrap: boolean;
+	indentSize: number;
+}
 
-const DEFAULT_SETTINGS: CssEditorPluginSettings = {};
+export const DEFAULT_SETTINGS: CssEditorPluginSettings = {
+	lineWrap: false,
+	indentSize: 2,
+};
 
 export default class CssEditorPlugin extends Plugin {
 	settings: CssEditorPluginSettings;
+	settingTab: CSSEditorSettingTab;
 
 	async onload() {
 		await this.loadSettings();
@@ -84,6 +92,9 @@ export default class CssEditorPlugin extends Plugin {
 		);
 
 		this.registerView(VIEW_TYPE_CSS, (leaf) => new CssEditorView(leaf));
+		
+		this.settingTab = new CSSEditorSettingTab(this.app, this);
+		this.addSettingTab(this.settingTab);
 	}
 
 	onunload() {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ export interface CssEditorPluginSettings {
 }
 
 export const DEFAULT_SETTINGS: CssEditorPluginSettings = {
-	lineWrap: false,
+	lineWrap: true,
 	indentSize: 2,
 };
 
@@ -91,7 +91,7 @@ export default class CssEditorPlugin extends Plugin {
 			)
 		);
 
-		this.registerView(VIEW_TYPE_CSS, (leaf) => new CssEditorView(leaf));
+		this.registerView(VIEW_TYPE_CSS, (leaf) => new CssEditorView(leaf, this));
 		
 		this.settingTab = new CSSEditorSettingTab(this.app, this);
 		this.addSettingTab(this.settingTab);

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,6 @@ import { CssSnippetCreateModal } from "./modals/CssSnippetCreateModal";
 import { CssFile } from "./CssFile";
 import { CSSEditorSettingTab } from "./obsidian/setting-tab";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CssEditorPluginSettings {
 	lineWrap: boolean;
 	indentSize: number;

--- a/src/obsidian/setting-tab.ts
+++ b/src/obsidian/setting-tab.ts
@@ -48,7 +48,7 @@ export class CSSEditorSettingTab extends PluginSettingTab {
 				field.onChange(val => {
 					val = val.replace(/\D/g, "");
 					field.setValue(val);
-					let size = parseInt(val);
+					const size = parseInt(val);
 					this.plugin.settings.indentSize = size;
 					this.plugin.saveSettings();
 					updateCSSEditorView(this.app, {

--- a/src/obsidian/setting-tab.ts
+++ b/src/obsidian/setting-tab.ts
@@ -1,6 +1,6 @@
 import { indentUnit } from "@codemirror/language";
 import { TransactionSpec } from "@codemirror/state";
-import { EditorView } from "codemirror";
+import { EditorView } from "@codemirror/view";
 import { App, PluginSettingTab, Setting } from "obsidian";
 import { indentSize, lineWrap } from "src/codemirror-extensions/compartments";
 import CssEditorPlugin from "src/main";

--- a/src/obsidian/setting-tab.ts
+++ b/src/obsidian/setting-tab.ts
@@ -1,0 +1,60 @@
+import { indentUnit } from "@codemirror/language";
+import { TransactionSpec } from "@codemirror/state";
+import { EditorView } from "codemirror";
+import { App, PluginSettingTab, Setting } from "obsidian";
+import { indentSize, lineWrap } from "src/codemirror-extensions/compartments";
+import CssEditorPlugin from "src/main";
+import { CssEditorView, VIEW_TYPE_CSS } from "src/views/CssEditorView";
+
+function updateCSSEditorView(app: App, spec: TransactionSpec) {
+	app.workspace.getLeavesOfType(VIEW_TYPE_CSS).forEach(leaf => {
+		if (leaf.view instanceof CssEditorView) {
+			leaf.view.dispatchEditorTransaction(spec);
+		}
+	});
+}
+
+export class CSSEditorSettingTab extends PluginSettingTab {
+	plugin: CssEditorPlugin;
+
+	constructor(app: App, plugin: CssEditorPlugin) {
+		super(app, plugin);
+		this.plugin = plugin;
+	}
+
+	display(): void {
+		this.containerEl.empty();
+
+		new Setting(this.containerEl)
+			.setName("Line wrap")
+			.setDesc("Toggle line wrap in the editor.")
+			.addToggle(toggle => {
+				toggle.setValue(this.plugin.settings.lineWrap);
+				toggle.onChange(val => {
+					this.plugin.settings.lineWrap = val;
+					this.plugin.saveSettings();
+					updateCSSEditorView(this.app, {
+						effects: lineWrap.reconfigure(val ? EditorView.lineWrapping : [])
+					});
+				});
+			});
+		
+		new Setting(this.containerEl)
+			.setName("Indent size")
+			.setDesc("Adjust the amount of spaces used for indentation.")
+			.addText(field => {
+				field.setPlaceholder("2");
+				field.setValue(this.plugin.settings.indentSize.toString());
+				field.onChange(val => {
+					val = val.replace(/\D/g, "");
+					field.setValue(val);
+					let size = parseInt(val);
+					this.plugin.settings.indentSize = size;
+					this.plugin.saveSettings();
+					updateCSSEditorView(this.app, {
+						effects: indentSize.reconfigure(indentUnit.of("".padEnd(size)))
+					});
+				});
+			});
+	}
+}

--- a/src/views/CssEditorView.ts
+++ b/src/views/CssEditorView.ts
@@ -7,6 +7,10 @@ import {
 	writeSnippetFile,
 } from "../obsidian/file-system-helpers";
 import { basicExtensions } from "../codemirror-extensions/basic-extensions";
+import { TransactionSpec } from "@codemirror/state";
+import CssEditorPlugin, { DEFAULT_SETTINGS } from "src/main";
+import { indentSize, lineWrap } from "src/codemirror-extensions/compartments";
+import { indentUnit } from "@codemirror/language";
 
 export const VIEW_TYPE_CSS = "css-editor-view";
 
@@ -16,11 +20,21 @@ export class CssEditorView extends ItemView {
 
 	constructor(leaf: WorkspaceLeaf) {
 		super(leaf);
+
+		let plugin = this.app.plugins.getPlugin("css-editor"),
+			settings = Object.assign({}, DEFAULT_SETTINGS);
+		
+		if (plugin instanceof CssEditorPlugin) {
+			settings = plugin.settings;
+		}
+
 		this.navigation = true;
 		this.editor = new EditorView({
 			parent: this.contentEl,
 			extensions: [
 				basicExtensions,
+				lineWrap.of(settings.lineWrap ? EditorView.lineWrapping : []),
+				indentSize.of(indentUnit.of("".padEnd(settings.indentSize))),
 				this.app.vault.getConfig?.("vimMode") ? vim() : [],
 				EditorView.updateListener.of((update) => {
 					if (update.docChanged) {
@@ -70,6 +84,10 @@ export class CssEditorView extends ItemView {
 
 	getEditorData() {
 		return this.editor.state.doc.toString();
+	}
+
+	dispatchEditorTransaction(...specs: TransactionSpec[]) {
+		this.editor.dispatch(...specs);
 	}
 
 	private dispatchEditorData(data: string) {

--- a/src/views/CssEditorView.ts
+++ b/src/views/CssEditorView.ts
@@ -8,7 +8,7 @@ import {
 } from "../obsidian/file-system-helpers";
 import { basicExtensions } from "../codemirror-extensions/basic-extensions";
 import { TransactionSpec } from "@codemirror/state";
-import CssEditorPlugin, { DEFAULT_SETTINGS } from "src/main";
+import CssEditorPlugin from "src/main";
 import { indentSize, lineWrap } from "src/codemirror-extensions/compartments";
 import { indentUnit } from "@codemirror/language";
 
@@ -18,15 +18,10 @@ export class CssEditorView extends ItemView {
 	private editor: EditorView;
 	private file: CssFile | null = null;
 
-	constructor(leaf: WorkspaceLeaf) {
+	constructor(leaf: WorkspaceLeaf, plugin: CssEditorPlugin) {
 		super(leaf);
 
-		let plugin = this.app.plugins.getPlugin("css-editor"),
-			settings = Object.assign({}, DEFAULT_SETTINGS);
-		
-		if (plugin instanceof CssEditorPlugin) {
-			settings = plugin.settings;
-		}
+		const { settings } = plugin;
 
 		this.navigation = true;
 		this.editor = new EditorView({


### PR DESCRIPTION
- Configurable line-wrap and indent size
- Line numbers
- Auto-completion for class and id selectors
- Give distinguishable style to the active line
- Use user-defined monospace font

Sample:
<details><summary>Details</summary>
<p>

![Screencast from 2025-03-16 23-42-39](https://github.com/user-attachments/assets/cd6155d6-6bcf-4c02-8045-91338e2e4615)
![Screencast from 2025-03-16 23-45-21](https://github.com/user-attachments/assets/7c6e6dee-9cbd-4502-8fab-db403189484c)


</p>
</details> 